### PR TITLE
fix(apigatewayv2-authorizers): require prop authorizerName when creating HttpUserPoolAuthorizer

### DIFF
--- a/packages/@aws-cdk/aws-apigatewayv2-authorizers/lib/http/user-pool.ts
+++ b/packages/@aws-cdk/aws-apigatewayv2-authorizers/lib/http/user-pool.ts
@@ -1,6 +1,6 @@
 import { HttpAuthorizer, HttpAuthorizerType, HttpRouteAuthorizerBindOptions, HttpRouteAuthorizerConfig, IHttpRouteAuthorizer } from '@aws-cdk/aws-apigatewayv2';
 import { IUserPool, IUserPoolClient } from '@aws-cdk/aws-cognito';
-import { Stack, Token } from '@aws-cdk/core';
+import { Stack } from '@aws-cdk/core';
 
 /**
  * Properties to initialize UserPoolAuthorizer.
@@ -24,9 +24,8 @@ export interface UserPoolAuthorizerProps {
 
   /**
    * The name of the authorizer
-   * @default 'UserPoolAuthorizer'
    */
-  readonly authorizerName?: string;
+  readonly authorizerName: string;
 
   /**
    * The identity source for which authorization is requested.
@@ -48,8 +47,7 @@ export class HttpUserPoolAuthorizer implements IHttpRouteAuthorizer {
 
   public bind(options: HttpRouteAuthorizerBindOptions): HttpRouteAuthorizerConfig {
     if (!this.authorizer) {
-      const id = this.props.authorizerName && !Token.isUnresolved(this.props.authorizerName) ?
-        this.props.authorizerName : 'UserPoolAuthorizer';
+      const id = this.props.authorizerName;
       const region = this.props.userPoolRegion ?? Stack.of(options.scope).region;
       this.authorizer = new HttpAuthorizer(options.scope, id, {
         httpApi: options.route.httpApi,

--- a/packages/@aws-cdk/aws-apigatewayv2-authorizers/test/http/integ.user-pool.ts
+++ b/packages/@aws-cdk/aws-apigatewayv2-authorizers/test/http/integ.user-pool.ts
@@ -23,9 +23,12 @@ const userPool = new cognito.UserPool(stack, 'userpool');
 
 const userPoolClient = userPool.addClient('my-client');
 
+const authorizerName = 'UserPoolAuthorizer';
+
 const authorizer = new HttpUserPoolAuthorizer({
   userPool,
   userPoolClient,
+  authorizerName,
 });
 
 const handler = new lambda.Function(stack, 'lambda', {

--- a/packages/@aws-cdk/aws-apigatewayv2-authorizers/test/http/user-pool.test.ts
+++ b/packages/@aws-cdk/aws-apigatewayv2-authorizers/test/http/user-pool.test.ts
@@ -11,9 +11,11 @@ describe('HttpUserPoolAuthorizer', () => {
     const api = new HttpApi(stack, 'HttpApi');
     const userPool = new UserPool(stack, 'UserPool');
     const userPoolClient = userPool.addClient('UserPoolClient');
+    const authorizerName = 'UserPoolAuthorizer';
     const authorizer = new HttpUserPoolAuthorizer({
       userPool,
       userPoolClient,
+      authorizerName,
     });
 
     // WHEN
@@ -50,9 +52,11 @@ describe('HttpUserPoolAuthorizer', () => {
     const api = new HttpApi(stack, 'HttpApi');
     const userPool = new UserPool(stack, 'UserPool');
     const userPoolClient = userPool.addClient('UserPoolClient');
+    const authorizerName = 'UserPoolAuthorizer';
     const authorizer = new HttpUserPoolAuthorizer({
       userPool,
       userPoolClient,
+      authorizerName,
     });
 
     // WHEN


### PR DESCRIPTION
Closes #13711

BREAKING CHANGE: Users now need to specify authorizerName prop or else build will fail
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
